### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Courses | School | Duration | Effort | Frequency | Prerequisites
 :-- | :--: | :--: | :--: | :--: | :--:
 [Java Programming: Solving Problems with Software](https://imp.i384100.net/GjkPGV)| Duke | 4 weeks | 4-8 hours/week | twice a month | none
 [Java Programming: Arrays, Lists, and Structured Data](https://imp.i384100.net/15knRR)| Duke | 4 weeks | 4-8 hours/week | twice a month | Java Programming: Solving Problems with Software
-[Object Oriented Programming in Java](https://imp.i384100.net/ZdznBq)| Duke | 6 weeks | 4-6 hours/week | every week | Java Programming: Arrays, Lists, and Structured Data
-[Data Structures and Performance](https://imp.i384100.net/oevm0b)| Duke | 6 weeks | 6-10 hours/week | every week | Object Oriented Programming in Java
+[Object Oriented Programming in Java](https://imp.i384100.net/ZdznBq)| UC SanDiago | 6 weeks | 4-6 hours/week | every week | Java Programming: Arrays, Lists, and Structured Data
+[Data Structures and Performance](https://imp.i384100.net/oevm0b)| UC SanDiago | 6 weeks | 6-10 hours/week | every week | Object Oriented Programming in Java
 [Java Programming: Principles of Software Design](https://imp.i384100.net/zavZrO) | Duke | 4 weeks | 4-8 hours/week | twice a month | Java Programming: Arrays, Lists, and Structured Data
 [Java Programming: Build a Recommendation System](https://imp.i384100.net/n1vro6) | Duke | 4 weeks | 3-6 hours/week | once a month | Java Programming: Principles of Software Design
-[Programming Languages, Part A](imp.i384100.net/6b13oK) | UW | 5 weeks | 8-16 hours/week | once a month | Object Oriented Programming in Java
-[Programming Languages, Part B](https://imp.i384100.net/2rebMz) | UW | 3 weeks | 8-16 hours/week | once a month | Programming Languages, Part A
-[Programming Languages, Part C](https://imp.i384100.net/Ryogm9) | UW | 3 weeks | 8-16 hours/week | once a month | Programming Languages, Part B
+[Programming Languages, Part A](https://imp.i384100.net/6b13oK) | University of Washington | 5 weeks | 8-16 hours/week | once a month | Object Oriented Programming in Java
+[Programming Languages, Part B](https://imp.i384100.net/2rebMz) | University of Washington | 3 weeks | 8-16 hours/week | once a month | Programming Languages, Part A
+[Programming Languages, Part C](https://imp.i384100.net/Ryogm9) | University of Washington | 3 weeks | 8-16 hours/week | once a month | Programming Languages, Part B
 
 ## Math
 
@@ -38,7 +38,7 @@ Courses | School | Duration | Effort | Frequency | Prerequisites
 
 Courses | School | Duration | Effort | Frequency | Prerequisites
 :-- | :--: | :--: | :--: | :--: | :--:
-[Build a Modern Computer from First Principles: From Nand to Tetris](imp.i384100.net/6b13dV) | Hebrew University of Jerusalem | 6 weeks | 5 hours/week | twice a month | basic programming knowledge
+[Build a Modern Computer from First Principles: From Nand to Tetris](https://imp.i384100.net/6b13dV) | Hebrew University of Jerusalem | 6 weeks | 5 hours/week | twice a month | basic programming knowledge
 [Build a Modern Computer from First Principles: From Nand to Tetris II](https://imp.i384100.net/dovNVq) | Hebrew University of Jerusalem | 6 weeks | 10-15 hours/week | once a month | Build a Modern Computer from First Principles: From Nand to Tetris
 [Introduction to Operating Systems](https://imp.i115008.net/introduction-to-operating-systems)| Georgia Tech | 8 weeks | 5-8 hours/week | self-paced | Build a Modern Computer from First Principles: From Nand to Tetris II
 


### PR DESCRIPTION
fix: Correct school name for Object Oriented Programming in Java & Data Structures and Performance to UC SanDiago to avoid learner confusion

fix: Fix broken links in Programming Languages, Part A & Build a Modern Computer from First Principles: From Nand to Tetris for more accessible content

fix: Update UW to University of Washington to avoid learner confusion
this commit fixes #58 